### PR TITLE
switch to pypi for ocp.wasm and lib3mf.wasm, update build123d to v0.11.0, enable exporters for all formats

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html lang="en">
   <head>
-    <script src="https://cdn.jsdelivr.net/pyodide/v0.28.0a3/full/pyodide.js"></script>
+    <script src="https://cdn.jsdelivr.net/pyodide/v0.29.4/full/pyodide.js"></script>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Build123d Sandbox</title>

--- a/frontend/public/python/setup.py
+++ b/frontend/public/python/setup.py
@@ -2,10 +2,6 @@ print("Starting package installation...")
 import micropip
 import sys
 
-micropip.set_index_urls(
-    ["https://yeicor.github.io/OCP.wasm", "https://pypi.org/simple"]
-)
-
 print("Mocking incompatible OS-level and server packages...")
 
 # 1. Mock pyperclip (relies on OS-level clipboards)
@@ -50,9 +46,25 @@ micropip.add_mock_package(
     },
 )
 
+# 6. Mock strict dependencies to satisfy build123d's package resolution.
+# Passing an empty `modules` dict prevents Micropip from creating dummy
+# modules that would overwrite the real ones loaded by the -OCP.wasm packages.
+micropip.add_mock_package("cadquery-ocp-novtk", "7.9.3.1", modules={})
+micropip.add_mock_package("lib3mf", "2.4.1", modules={})
+
 print("Installing core dependencies (using upstream ocp_vscode)...")
-# Install standard upstream packages instead of the custom fork
-await micropip.install(["lib3mf", "ssl", "ocp_vscode==3.1.2", "build123d", "sqlite3"])
+# Install the WASM variants explicitly pinned to match build123d 0.11.0 expectations
+await micropip.install(
+    [
+        "cadquery-ocp-novtk-OCP.wasm==7.9.3.1.post202605200208",
+        "lib3mf-OCP.wasm==2.5.0.post202605200051",
+        "ssl",
+        "ocp_vscode==3.1.2",
+        "build123d==0.11.0",  # NOTE: update necessary pins
+        "sqlite3",
+    ],
+    keep_going=True,
+)
 # NOTE: to update ocp_vscode one must also update the required three-cad-viewer version
 # e.g. npm install three-cad-viewer@4.1.2 at time of writing
 

--- a/frontend/src/components/Editor.tsx
+++ b/frontend/src/components/Editor.tsx
@@ -177,11 +177,11 @@ function Editor(props: {
                                 }}
                             >
                                 <MenuItem value="BREP">BREP</MenuItem>
-                                <MenuItem value="STL" disabled>STL</MenuItem>
-                                <MenuItem value="STEP" disabled>STEP</MenuItem>
-                                <MenuItem value="SVG" disabled>SVG</MenuItem>
-                                <MenuItem value="DXF" disabled>DXF</MenuItem>
-                                <MenuItem value="3MF" disabled>3MF</MenuItem>
+                                <MenuItem value="STL">STL</MenuItem>
+                                <MenuItem value="STEP">STEP</MenuItem>
+                                <MenuItem value="SVG">SVG</MenuItem>
+                                <MenuItem value="DXF">DXF</MenuItem>
+                                <MenuItem value="3MF">3MF</MenuItem>
                             </Select>
                         </FormControl>
                         <Button

--- a/frontend/src/utils/PythonRuntime.ts
+++ b/frontend/src/utils/PythonRuntime.ts
@@ -128,19 +128,25 @@ export class PythonRuntime {
                     if format_type == "BREP":
                         b3d.export_brep(shape, bio)
                     elif format_type == "STL":
-                        # TODO: add lib3mf STL export workaround via Mesher (shape, bio)
-                        pass
+                        # lib3mf STL export workaround via Mesher (shape, bio)
+                        exporter = b3d.Mesher()
+                        exporter.add_shape(shape)
+                        exporter.write_stream(bio, "stl")
                     elif format_type == "STEP":
                         b3d.export_step(shape, bio)
                     elif format_type == "SVG":
-                        # TODO: add SVG export via ExportSVG (shape, bio)
-                        pass
+                        exporter = b3d.ExportSVG()
+                        exporter.add_shape(shape)
+                        exporter.write(bio)
                     elif format_type == "DXF":
-                        # TODO: add DXF export via ExportDXF (shape, bio)
-                        pass
+                        exporter = b3d.ExportDXF()
+                        exporter.add_shape(shape)
+                        exporter.write(bio)
                     elif format_type == "3MF":
-                        # TODO: add lib3mf 3MF export via Mesher (shape, bio)
-                        pass
+                        # lib3mf 3MF export via Mesher (shape, bio)
+                        exporter = b3d.Mesher()
+                        exporter.add_shape(shape)
+                        exporter.write_stream(bio, "3mf")
                     else:
                         print(f"Unknown format: {format_type}")
                         return None


### PR DESCRIPTION
- Had to switch to pyodide==0.29.4 to get proper tag compat on pypi
- switch to *ocp.wasm and *lib3mf.wasm on pypi from Yeicor (away from github.io)
- Enabled and tested file export locally for remaining file formats that were previously disabled. (STEP, STL, 3MF, DXF, SVG)
- This fixes broken build123d-sandbox caused by new release of build123d==0.11.0 earlier today.