### PR TITLE
Reorder MenuItem options in Editor component, STEP first

### DIFF
--- a/frontend/src/components/Editor.tsx
+++ b/frontend/src/components/Editor.tsx
@@ -176,12 +176,12 @@ function Editor(props: {
                                     borderBottomRightRadius: 0,
                                 }}
                             >
-                                <MenuItem value="BREP">BREP</MenuItem>
-                                <MenuItem value="STL">STL</MenuItem>
                                 <MenuItem value="STEP">STEP</MenuItem>
+                                <MenuItem value="STL">STL</MenuItem>
+                                <MenuItem value="3MF">3MF</MenuItem>
                                 <MenuItem value="SVG">SVG</MenuItem>
                                 <MenuItem value="DXF">DXF</MenuItem>
-                                <MenuItem value="3MF">3MF</MenuItem>
+                                <MenuItem value="BREP">BREP</MenuItem>
                             </Select>
                         </FormControl>
                         <Button


### PR DESCRIPTION
In my last PR I forgot to re-order the menu items to emphasize STEP export as the default export format. New order:

```
STEP
STL
3MF
...
```